### PR TITLE
Spatial URIs

### DIFF
--- a/configs/utk_dc.yml
+++ b/configs/utk_dc.yml
@@ -228,7 +228,6 @@ mapping:
   - name: spatial
     xpaths:
       - 'mods:subject/mods:geographic/@valueURI'
-      - 'mods:subject[mods:geographic]/@valueURI'
     properties:
       - "http://purl.org/dc/terms/spatial"
     special: "GeoNamesProperty"

--- a/configs/utk_dc.yml
+++ b/configs/utk_dc.yml
@@ -235,7 +235,7 @@ mapping:
   - name: spatial_local
     xpaths:
       - 'mods:subject/mods:geographic[not(@valueURI)]'
-      - 'mods:subject[not(@valueURI)]/mods:geographic'
+      - 'mods:subject[not(@valueURI)]/mods:geographic[not(@valueURI)]'
     property: "http://id.loc.gov/ontologies/bibframe/geographicCoverage"
 
   - name: coordinates

--- a/configs/utk_dc.yml
+++ b/configs/utk_dc.yml
@@ -228,6 +228,7 @@ mapping:
   - name: spatial
     xpaths:
       - 'mods:subject/mods:geographic/@valueURI'
+      - 'mods:subject[mods:geographic]/@valueURI'
     properties:
       - "http://purl.org/dc/terms/spatial"
     special: "GeoNamesProperty"
@@ -235,7 +236,8 @@ mapping:
   - name: spatial_local
     xpaths:
       - 'mods:subject/mods:geographic[not(@valueURI)]'
-    property: "http://purl.org/dc/terms/spatial"
+      - 'mods:subject[not(@valueURI)]/mods:geographic'
+    property: "http://id.loc.gov/ontologies/bibframe/geographicCoverage"
 
   - name: coordinates
     xpaths:

--- a/exodus/exodus.py
+++ b/exodus/exodus.py
@@ -212,7 +212,7 @@ class GeoNamesProperty(BaseProperty):
         ]
         lc_uris = [
             uri
-            for uri in self.root.xpath('mods:subject[mods:geographic]@valueURI', namespaces=self.namespaces)
+           for uri in self.root.xpath('mods:subject[mods:geographic]/@valueURI', namespaces=self.namespaces)
         ]
         all_values = []
         for uri in lc_uris:

--- a/exodus/exodus.py
+++ b/exodus/exodus.py
@@ -210,7 +210,13 @@ class GeoNamesProperty(BaseProperty):
             uri.replace('about.rdf', '')
             for uri in self.root.xpath('mods:subject/mods:geographic/@valueURI', namespaces=self.namespaces)
         ]
+        lc_uris = [
+            uri
+            for uri in self.root.xpath('mods:subject[mods:geographic]@valueURI', namespaces=self.namespaces)
+        ]
         all_values = []
+        for uri in lc_uris:
+            all_values.append(uri)
         for uri in uris:
             all_values.append(uri)
         return {name: all_values}

--- a/exodus/exodus.py
+++ b/exodus/exodus.py
@@ -212,7 +212,7 @@ class GeoNamesProperty(BaseProperty):
         ]
         lc_uris = [
             uri
-           for uri in self.root.xpath('mods:subject[mods:geographic]/@valueURI', namespaces=self.namespaces)
+            for uri in self.root.xpath('mods:subject[mods:geographic]/@valueURI', namespaces=self.namespaces)
         ]
         all_values = []
         for uri in lc_uris:


### PR DESCRIPTION
## What does this Pull Request do?

Currently Exodus does not bring over URIs associated with geographic subjects in MODS unless the URI is on the geographic element. This PR primarily addresses this issue by adding the missing Xpath (subject[@valueURI]/geographic). For documentation purposes, the correct property URI has also been added for spatial_local (http://id.loc.gov/ontologies/bibframe/geographicCoverage) and Xpaths added the utk_dc config for spatial and spatial_local.

## How should this be tested?

- Ensure that the Xpaths are accurate
- Test with these MODS records: 
  - URI on subject: https://digital.lib.utk.edu/collections/islandora/object/garner%3A1/datastream/MODS/view
  - URI on geographic: https://digital.lib.utk.edu/collections/islandora/object/roth%3A2165/datastream/MODS/view

## Interested Parties

@markpbaggett 
