### PR TITLE
Subject changes for collection metadata

### DIFF
--- a/exodus/helpers/get_collection_data.py
+++ b/exodus/helpers/get_collection_data.py
@@ -39,7 +39,7 @@ class CollectionMetadata:
             "publication_place": self.__simplify_xpath('mods:originInfo/mods:place/mods:placeTerm[@valueURI]'),
             "extent": self.__simplify_xpath('mods:physicalDescription/mods:extent'),
             "form": self.__get_valueURIs('mods:physicalDescription/mods:form/@valueURI'),
-            "subject": self.__get_valueURIs('mods:subject[mods:topic]/@valueURI'),
+            "subject": self.__get_valueURIs('mods:subject[mods:topic]/@valueURI' OR 'mods:subject/mods:topic/@valueURI'),
             "keyword": self.__simplify_xpath('mods:subject[not(@valueURI)]/mods:topic'),
             "spatial": self.__get_valueURIs('mods:subject/mods:geographic/@valueURI' OR 'mods:subject[mods:geographic]/@valueURI'),
             "resource_type": "",

--- a/exodus/helpers/get_collection_data.py
+++ b/exodus/helpers/get_collection_data.py
@@ -41,7 +41,7 @@ class CollectionMetadata:
             "form": self.__get_valueURIs('mods:physicalDescription/mods:form/@valueURI'),
             "subject": self.__get_valueURIs('mods:subject[mods:topic]/@valueURI'),
             "keyword": self.__simplify_xpath('mods:subject[not(@valueURI)]/mods:topic'),
-            "spatial": self.__get_valueURIs('mods:subject/mods:geographic/@valueURI'),
+            "spatial": self.__get_valueURIs('mods:subject/mods:geographic/@valueURI' OR 'mods:subject[mods:geographic]/@valueURI'),
             "resource_type": "",
             "repository": self.__get_valueURIs('mods:location/mods:physicalLocation/@valueURI'),
             "note": self.__simplify_xpath('mods:note')


### PR DESCRIPTION
## What does this Pull Request do?

This PR adds a few Xpaths for the properties spatial and subject associated with collection-level metadata. It looks like my original Xpaths did not account for when a valueURI is on the subject element of a geographic subject. I noticed that there are no spatial subjects present on Hyku for the current AC Wiley collection record, but the following is in the metadata:

`    <subject authority="naf" valueURI="http://id.loc.gov/authorities/names/n79109786">
        <geographic>Knoxville (Tenn.)</geographic>
        <cartographics>
            <coordinates>35.96064, -83.92074</coordinates>
        </cartographics>
    </subject>`

I also noticed that mods:subject/mods:name values are not accounted for in any of the current Xpaths. Two Xpaths have been added to subject for these.

## How should this be tested?

Test the Xpaths on collection records. Regenerate spreadsheets for collection metadata that have spatial subjects and name subjects and ensure that they are there. AC Wiley should have a spatial subject. All of the athletics media guides collections should have names present (e.g. Football, Basketball, etc.).

## Interested parties

@markpbaggett
